### PR TITLE
Fix for inclusion in multiple CPP files

### DIFF
--- a/include/mmtf/binary_decoder.hpp
+++ b/include/mmtf/binary_decoder.hpp
@@ -140,8 +140,9 @@ void arrayCopyBigendian2(void* dst, const char* src, size_t n) {
 
 } // anon ns
 
-BinaryDecoder::BinaryDecoder(const msgpack::object& obj, const std::string& key)
-                            : key_(key) {
+inline BinaryDecoder::BinaryDecoder(const msgpack::object& obj,
+                                    const std::string& key)
+                                   : key_(key) {
     // sanity checks
     if (obj.type != msgpack::type::BIN) {
         throw DecodeError("The '" + key + "' entry is not binary data");
@@ -167,7 +168,7 @@ void BinaryDecoder::decode(T& target) {
 }
 
 template<>
-void BinaryDecoder::decode(std::vector<float>& output) {
+inline void BinaryDecoder::decode(std::vector<float>& output) {
     // check strategy to parse
     switch (strategy_) {
     case 1: {
@@ -226,7 +227,7 @@ void BinaryDecoder::decode(std::vector<float>& output) {
 }
 
 template<>
-void BinaryDecoder::decode(std::vector<int8_t>& output) {
+inline void BinaryDecoder::decode(std::vector<int8_t>& output) {
     // check strategy to parse
     switch (strategy_) {
     case 2: {
@@ -246,7 +247,7 @@ void BinaryDecoder::decode(std::vector<int8_t>& output) {
 }
 
 template<>
-void BinaryDecoder::decode(std::vector<int16_t>& output) {
+inline void BinaryDecoder::decode(std::vector<int16_t>& output) {
     // check strategy to parse
     switch (strategy_) {
     case 3: {
@@ -266,7 +267,7 @@ void BinaryDecoder::decode(std::vector<int16_t>& output) {
 }
 
 template<>
-void BinaryDecoder::decode(std::vector<int32_t>& output) {
+inline void BinaryDecoder::decode(std::vector<int32_t>& output) {
     // check strategy to parse
     switch (strategy_) {
     case 4: {
@@ -311,7 +312,7 @@ void BinaryDecoder::decode(std::vector<int32_t>& output) {
 }
 
 template<>
-void BinaryDecoder::decode(std::vector<std::string>& output) {
+inline void BinaryDecoder::decode(std::vector<std::string>& output) {
     // check strategy to parse
     switch (strategy_) {
     case 5: {
@@ -331,7 +332,7 @@ void BinaryDecoder::decode(std::vector<std::string>& output) {
 }
 
 template<>
-void BinaryDecoder::decode(std::vector<char>& output) {
+inline void BinaryDecoder::decode(std::vector<char>& output) {
     // check strategy to parse
     switch (strategy_) {
     case 6: {
@@ -353,7 +354,7 @@ void BinaryDecoder::decode(std::vector<char>& output) {
 }
 
 // checks
-void BinaryDecoder::checkLength_(int32_t exp_length) {
+inline void BinaryDecoder::checkLength_(int32_t exp_length) {
     if (length_ != exp_length) {
         std::stringstream err;
         err << "Length mismatch for binary '" + key_ + "': "
@@ -362,7 +363,7 @@ void BinaryDecoder::checkLength_(int32_t exp_length) {
     }
 }
 
-void BinaryDecoder::checkDivisibleBy_(int32_t item_size) {
+inline void BinaryDecoder::checkDivisibleBy_(int32_t item_size) {
     if (encodedDataLength_ % item_size != 0) {
         std::stringstream err;
         err << "Binary length of '" + key_ + "': "
@@ -372,27 +373,27 @@ void BinaryDecoder::checkDivisibleBy_(int32_t item_size) {
 }
 
 // byte decoders
-void BinaryDecoder::decodeFromBytes_(std::vector<float>& output) {
+inline void BinaryDecoder::decodeFromBytes_(std::vector<float>& output) {
     checkDivisibleBy_(4);
     // prepare memory
     output.resize(encodedDataLength_ / 4);
     // get data
     arrayCopyBigendian4(&output[0], encodedData_, encodedDataLength_);
 }
-void BinaryDecoder::decodeFromBytes_(std::vector<int8_t>& output) {
+inline void BinaryDecoder::decodeFromBytes_(std::vector<int8_t>& output) {
     // prepare memory
     output.resize(encodedDataLength_);
     // get data
     memcpy(&output[0], encodedData_, encodedDataLength_);
 }
-void BinaryDecoder::decodeFromBytes_(std::vector<int16_t>& output) {
+inline void BinaryDecoder::decodeFromBytes_(std::vector<int16_t>& output) {
     checkDivisibleBy_(2);
     // prepare memory
     output.resize(encodedDataLength_ / 2);
     // get data
     arrayCopyBigendian2(&output[0], encodedData_, encodedDataLength_);
 }
-void BinaryDecoder::decodeFromBytes_(std::vector<int32_t>& output) {
+inline void BinaryDecoder::decodeFromBytes_(std::vector<int32_t>& output) {
     checkDivisibleBy_(4);
     // prepare memory
     output.resize(encodedDataLength_ / 4);
@@ -400,7 +401,7 @@ void BinaryDecoder::decodeFromBytes_(std::vector<int32_t>& output) {
     arrayCopyBigendian4(&output[0], encodedData_, encodedDataLength_);
 }
 // special one: decode to vector of strings
-void BinaryDecoder::decodeFromBytes_(std::vector<std::string>& output) {
+inline void BinaryDecoder::decodeFromBytes_(std::vector<std::string>& output) {
     char NULL_BYTE = 0x00;
     // check parameter
     const int32_t str_len = parameter_;

--- a/include/mmtf/map_decoder.hpp
+++ b/include/mmtf/map_decoder.hpp
@@ -87,7 +87,7 @@ private:
 // IMPLEMENTATION
 // *************************************************************************
 
-MapDecoder::MapDecoder(const msgpack::object& obj) {
+inline MapDecoder::MapDecoder(const msgpack::object& obj) {
     // sanity checks
     if (obj.type != msgpack::type::MAP) {
         throw DecodeError("Expected msgpack type to be MAP");
@@ -129,7 +129,7 @@ void MapDecoder::decode(const std::string& key, bool required, T& target) {
     }
 }
 
-void MapDecoder::checkExtraKeys() {
+inline void MapDecoder::checkExtraKeys() {
     // note: cost of O(N*log(M))) string comparisons (M parsed, N in map)
     // simple set difference algorithm
     std::map<std::string, msgpack::object*>::iterator map_it;
@@ -143,34 +143,34 @@ void MapDecoder::checkExtraKeys() {
     }
 }
 
-void MapDecoder::checkType_(const std::string& key,
-                            msgpack::type::object_type type,
-                            const float& target) {
+inline void MapDecoder::checkType_(const std::string& key,
+                                   msgpack::type::object_type type,
+                                   const float& target) {
     if (type != msgpack::type::FLOAT32 && type != msgpack::type::FLOAT64) {
         std::cerr << "Warning: Non-float type " << type << " found for "
                      "entry " << key << std::endl;
     }
 }
-void MapDecoder::checkType_(const std::string& key,
-                            msgpack::type::object_type type,
-                            const int32_t& target) {
+inline void MapDecoder::checkType_(const std::string& key,
+                                   msgpack::type::object_type type,
+                                   const int32_t& target) {
     if (   type != msgpack::type::POSITIVE_INTEGER
         && type != msgpack::type::NEGATIVE_INTEGER) {
         std::cerr << "Warning: Non-int type " << type << " found for "
                      "entry " << key << std::endl;
     }
 }
-void MapDecoder::checkType_(const std::string& key,
-                            msgpack::type::object_type type,
-                            const char& target) {
+inline void MapDecoder::checkType_(const std::string& key,
+                                   msgpack::type::object_type type,
+                                   const char& target) {
     if (type != msgpack::type::STR) {
         std::cerr << "Warning: Non-string type " << type << " found for "
                      "entry " << key << std::endl;
     }
 }
-void MapDecoder::checkType_(const std::string& key,
-                            msgpack::type::object_type type,
-                            const std::string& target) {
+inline void MapDecoder::checkType_(const std::string& key,
+                                   msgpack::type::object_type type,
+                                   const std::string& target) {
     if (type != msgpack::type::STR) {
         std::cerr << "Warning: Non-string type " << type << " found for "
                      "entry " << key << std::endl;

--- a/include/mmtf/structure_data.hpp
+++ b/include/mmtf/structure_data.hpp
@@ -439,7 +439,7 @@ bool is_hetatm(const char* type) {
 
 // CLASS StructureData
 
-StructureData::StructureData() {
+inline StructureData::StructureData() {
   // no need to do anything with strings and vectors
   setDefaultValue(resolution);
   setDefaultValue(rFree);
@@ -455,7 +455,7 @@ StructureData::StructureData() {
   mmtfProducer = "mmtf-cpp library (github.com/rcsb/mmtf-cpp)";
 }
 
-bool StructureData::hasConsistentData(bool verbose, int32_t chain_name_max_length) const {
+inline bool StructureData::hasConsistentData(bool verbose, int32_t chain_name_max_length) const {
   // check unitCell: if given, must be of length 6
   if (!hasRightSizeOptional(unitCell, 6)) {
     if (verbose) {
@@ -746,7 +746,7 @@ bool StructureData::hasConsistentData(bool verbose, int32_t chain_name_max_lengt
   return true;
 }
 
-std::string StructureData::print(std::string delim) {
+inline std::string StructureData::print(std::string delim) {
   std::ostringstream out;
   int modelIndex = 0;
   int chainIndex = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,3 +5,7 @@ add_executable(mmtf_tests mmtf_tests.cpp)
 target_compile_features(mmtf_tests PRIVATE cxx_auto_type)
 target_link_libraries(mmtf_tests Catch msgpackc MMTFcpp)
 
+# test for multi-linking
+add_executable(multi_cpp_test multi_cpp_test.cpp multi_cpp_test_helper.cpp)
+target_compile_features(multi_cpp_test PRIVATE cxx_auto_type)
+target_link_libraries(multi_cpp_test MMTFcpp)

--- a/tests/multi_cpp_test.cpp
+++ b/tests/multi_cpp_test.cpp
@@ -1,0 +1,17 @@
+// *************************************************************************
+//
+// Simple test for compilation issues.
+//
+// *************************************************************************
+
+#include <mmtf.hpp>
+#include "multi_cpp_test_helper.hpp"
+
+int main(int argc, char** argv) {
+    // decode MMTF file
+    std::string filename = "../mmtf_spec/test-suite/mmtf/173D.mmtf";
+    mmtf::StructureData data;
+    read_check_file(data, filename);
+
+    return 0;
+}

--- a/tests/multi_cpp_test_helper.cpp
+++ b/tests/multi_cpp_test_helper.cpp
@@ -1,0 +1,20 @@
+// *************************************************************************
+//
+// Simple test for compilation issues.
+//
+// *************************************************************************
+
+#include "multi_cpp_test_helper.hpp"
+#include <iostream>
+
+void read_check_file(mmtf::StructureData& data, const std::string& filename) {
+    // decode MMTF file
+    mmtf::decodeFromFile(data, filename);
+
+    // check if the data is self-consistent
+    if (data.hasConsistentData()) {
+      std::cout << "Successfully read " << filename << ".\n";
+    } else {
+      std::cout << "Inconsistent data in " << filename << ".\n";
+    }
+}

--- a/tests/multi_cpp_test_helper.hpp
+++ b/tests/multi_cpp_test_helper.hpp
@@ -1,0 +1,10 @@
+// *************************************************************************
+//
+// Simple test for compilation issues.
+//
+// *************************************************************************
+
+#include <mmtf.hpp>
+#include <string>
+
+void read_check_file(mmtf::StructureData& data, const std::string& filename);


### PR DESCRIPTION
Attempting to include `structure_data.hpp` in more than one translation unit results in linkage errors as three functions are defined multiple times. See [this article](https://stackoverflow.com/questions/212006/multiple-definition-error-including-c-header-file-with-inline-code-from-multip) for details.