### PR TITLE
Danpf/msgpack lock to release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ libraries. The MMTF specification can be found
 
 ## Prerequisites for using MMTF in C++
 
-You need the headers of the MessagePack C++ library (version 2.1.1 or newer).
+You need the headers of the MessagePack C++ library (version 2.1.5 or newer).
 If you do not have them on your machine already, you can download the "include"
 directory from the
 [MessagePack GitHub repository](https://github.com/msgpack/msgpack-c).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,6 @@ environment:
       ARCH: x86
 
 clone_folder: c:\mmtf-cpp
-clone_script:
-- cmd: git clone -q --recursive --branch=%APPVEYOR_REPO_BRANCH% https://github.com/%APPVEYOR_REPO_NAME%.git %APPVEYOR_BUILD_FOLDER%
-- cmd: git checkout -qf %APPVEYOR_REPO_COMMIT%
 
 # Uncomment the following lines to enable remote desktop access to Appveyor
 # after a failed build.
@@ -29,6 +26,7 @@ clone_script:
 #   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 install:
+  - git submodule update --init --recursive
   - ps: . .\ci\setup-appveyor.ps1
 
 build_script:


### PR DESCRIPTION
We should lock to a msgpack release SHA instead of a 'random' SHA.

this locks us to 2.1.5

reference: #7 