### PR TITLE
Danpf/fix bond order consistency

### DIFF
--- a/include/mmtf/structure_data.hpp
+++ b/include/mmtf/structure_data.hpp
@@ -517,14 +517,14 @@ inline bool StructureData::hasConsistentData(bool verbose, uint32_t chain_name_m
     const size_t num_atoms = g.formalChargeList.size();
     if (g.atomNameList.size() != num_atoms) {
       if (verbose) {
-        std::cout << "inconsistent group::atomNameList size: "
+        std::cout << "inconsistent group::atomNameList size at idx: "
             << i << std::endl;
       }
       return false;
     }
     if (g.elementList.size() != num_atoms) {
       if (verbose) {
-        std::cout << "inconsistent group::elementList size: "
+        std::cout << "inconsistent group::elementList size at idx: "
             << i << std::endl;
       }
       return false;
@@ -541,8 +541,8 @@ inline bool StructureData::hasConsistentData(bool verbose, uint32_t chain_name_m
     }
     if (!hasValidIndices(g.bondAtomList, num_atoms)) {
       if (verbose) {
-        std::cout << "inconsistent group::bondAtomList indicies: "
-            << i << std::endl;
+        std::cout << "inconsistent group::bondAtomList indices (not all in [0, "
+            << num_atoms - 1 << "]) at idx: " << i << std::endl;
       }
       return false;
     }
@@ -551,7 +551,7 @@ inline bool StructureData::hasConsistentData(bool verbose, uint32_t chain_name_m
   if (!isDefaultValue(bondOrderList)) {
     if (bondAtomList.size() != bondOrderList.size() * 2) {
       if (verbose) {
-          std::cout << "inconsistent bondAtomList size :" <<
+          std::cout << "inconsistent bondAtomList size: " <<
               bondAtomList.size() << " != bondOrderList size(*2): " <<
               bondOrderList.size()*2 << std::endl;
       }
@@ -560,7 +560,8 @@ inline bool StructureData::hasConsistentData(bool verbose, uint32_t chain_name_m
   }
   if (!hasValidIndices(bondAtomList, numAtoms)) {
     if (verbose) {
-      std::cout << "inconsistent bondAtomList indicies" << std::endl;
+      std::cout << "inconsistent bondAtomList indices (not all in [0, "
+          << numAtoms - 1 << "])" << std::endl;
     }
     return false;
   }
@@ -664,8 +665,8 @@ inline bool StructureData::hasConsistentData(bool verbose, uint32_t chain_name_m
   // check indices
   if (!hasValidIndices(groupTypeList, groupList.size())) {
     if (verbose) {
-      std::cout << "inconsistent groupTypeList indicies " <<
-          "Not between 0->" << groupList.size() <<  std::endl;
+      std::cout << "inconsistent groupTypeList indices (not all in [0, "
+          << groupList.size() - 1 << "])" << std::endl;
     }
     return false;
   }

--- a/include/mmtf/structure_data.hpp
+++ b/include/mmtf/structure_data.hpp
@@ -459,20 +459,22 @@ inline bool StructureData::hasConsistentData(bool verbose, uint32_t chain_name_m
   // check unitCell: if given, must be of length 6
   if (!hasRightSizeOptional(unitCell, 6)) {
     if (verbose) {
-      std::cout << "inconsistent unitCell" << std::endl;
+      std::cout << "inconsistent unitCell (unitCell length != 6)" << std::endl;
     }
     return false;
   }
   // check dates
   if (!isValidDateFormatOptional(depositionDate)) {
     if (verbose) {
-      std::cout << "inconsistent depositionDate" << std::endl;
+      std::cout << "inconsistent depositionDate (does not match 'YYYY-MM-DD' "
+          "or empty)" << std::endl;
     }
     return false;
   }
   if (!isValidDateFormatOptional(releaseDate)) {
     if (verbose) {
-      std::cout << "inconsistent releaseDate" << std::endl;
+      std::cout << "inconsistent releaseDate (does not match 'YYYY-MM-DD' "
+          "or empty)" << std::endl;
     }
     return false;
   }
@@ -480,8 +482,8 @@ inline bool StructureData::hasConsistentData(bool verbose, uint32_t chain_name_m
   for (size_t i = 0; i < ncsOperatorList.size(); ++i) {
     if ((int)ncsOperatorList[i].size() != 16) {
       if (verbose) {
-        std::cout << "inconsistent ncsOperatorList idx: "
-            << i << std::endl;
+        std::cout << "inconsistent ncsOperatorList idx: " << i << " found size: "
+            << ncsOperatorList[i].size() << " != 16" << std::endl;
       }
       return false;
     }
@@ -656,7 +658,8 @@ inline bool StructureData::hasConsistentData(bool verbose, uint32_t chain_name_m
   // check indices
   if (!hasValidIndices(groupTypeList, groupList.size())) {
     if (verbose) {
-      std::cout << "inconsistent groupTypeList size" << std::endl;
+      std::cout << "inconsistent groupTypeList indicies " <<
+          "Not between 0->" << groupList.size() <<  std::endl;
     }
     return false;
   }

--- a/tests/mmtf_tests.cpp
+++ b/tests/mmtf_tests.cpp
@@ -461,6 +461,27 @@ TEST_CASE("Test FourByteInt enc/dec") {
 	REQUIRE(decoded_data == decoded_input);
 }
 
+TEST_CASE("Test bondOrderList vs bondAtomList") {
+	std::string working_mmtf = "../mmtf_spec/test-suite/mmtf/173D.mmtf";
+	mmtf::StructureData sd;
+	mmtf::decodeFromFile(sd, working_mmtf);
+	SECTION("Deleting all bondOrderLists") {
+		for (auto & group : sd.groupList) {
+			group.bondOrderList.clear();
+		}
+		sd.bondOrderList.clear();
+		REQUIRE(sd.hasConsistentData(true) == true);
+	}
+	SECTION("altering group bondOrderLists") {
+		sd.groupList[0].bondOrderList.push_back(1);
+		REQUIRE(sd.hasConsistentData(true) == false);
+	}
+	SECTION("altering sd bondOrderLists") {
+		sd.bondOrderList.push_back(1);
+		REQUIRE(sd.hasConsistentData(true) == false);
+	}
+}
+
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 

--- a/tests/mmtf_tests.cpp
+++ b/tests/mmtf_tests.cpp
@@ -94,6 +94,19 @@ TEST_CASE("Test round trip StructureData not working - EncodeError") {
 		sd.chainIdList[0] = "IheartMMTF";
 		REQUIRE_THROWS_AS(mmtf::encodeToFile(sd, "test_mmtf.mmtf"), mmtf::EncodeError);
 	}
+	SECTION("Alter single groupList entry") {
+		sd.groupList[0].formalChargeList.pop_back();
+		REQUIRE_THROWS_AS(mmtf::encodeToFile(sd, "test_mmtf.mmtf"), mmtf::EncodeError);
+		sd.groupList[0].atomNameList.pop_back();
+		REQUIRE_THROWS_AS(mmtf::encodeToFile(sd, "test_mmtf.mmtf"), mmtf::EncodeError);
+		sd.groupList[0].elementList.pop_back();
+		REQUIRE_THROWS_AS(mmtf::encodeToFile(sd, "test_mmtf.mmtf"), mmtf::EncodeError);
+	}
+	SECTION("Alter groupTypeList") {
+		sd.groupTypeList[0] = 100;
+		REQUIRE_THROWS_AS(mmtf::encodeToFile(sd, "test_mmtf.mmtf"), mmtf::EncodeError);
+	}
+
 }
 
 


### PR DESCRIPTION
We shouldn't require that you have to have both bondOrder and bondAtomList.
At least according to the spec.

This should fix that and I added some tests to make sure it doesn't
happen again

Also added a little better reporting in a few places where is consistent fails