### PR TITLE
export_helpers: BondAdder, compressGroupList

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
-SET(executables mmtf_demo traverse print_as_pdb)
+SET(executables mmtf_demo traverse print_as_pdb tableexport)
 
 foreach(exe ${executables})
 	add_executable(${exe} ${exe}.cpp)

--- a/examples/tableexport.cpp
+++ b/examples/tableexport.cpp
@@ -1,0 +1,147 @@
+// *************************************************************************
+//
+// Licensed under the MIT License (see accompanying LICENSE file).
+//
+// The authors of this code is Thomas Holder
+//
+// *************************************************************************
+//
+// This example demonstrates how to export molecular data which is given
+// as atom and bond tables.
+//
+// *************************************************************************
+
+#include <mmtf.hpp>
+#include <mmtf/export_helpers.hpp>
+
+#include <iostream>
+#include <string>
+
+/*
+ * Atom table of example "ALA-GLY-ALA" tripeptide
+ */
+struct Atom {
+  std::string chain;
+  int residue_number;
+  std::string residue_name;
+  std::string atom_name;
+  std::string element;
+  int formal_charge;
+  float x, y, z;
+} atomarray[] = {
+  {"A", 1, "ALA", "N",  "N", 0, -0.677, -1.230, -0.491},
+  {"A", 1, "ALA", "CA", "C", 0, -0.001,  0.064, -0.491},
+  {"A", 1, "ALA", "C",  "C", 0,  1.499, -0.110, -0.491},
+  {"A", 1, "ALA", "O",  "O", 0,  2.030, -1.227, -0.502},
+  {"A", 1, "ALA", "CB", "C", 0, -0.509,  0.856,  0.727},
+  {"A", 2, "GLY", "N",  "N", 0,  2.250,  0.939, -0.479},
+  {"A", 2, "GLY", "CA", "C", 0,  3.700,  0.771, -0.479},
+  {"A", 2, "GLY", "C",  "C", 0,  4.400,  2.108, -0.463},
+  {"A", 2, "GLY", "O",  "O", 0,  3.775,  3.173, -0.453},
+  {"A", 3, "ALA", "N",  "N", 0,  5.689,  2.140, -0.462},
+  {"A", 3, "ALA", "CA", "C", 0,  6.365,  3.434, -0.447},
+  {"A", 3, "ALA", "C",  "C", 0,  7.865,  3.260, -0.447},
+  {"A", 3, "ALA", "O",  "O", 0,  8.396,  2.144, -0.470},
+  {"A", 3, "ALA", "CB", "C", 0,  5.855,  4.213,  0.778}
+};
+
+/*
+ * Bond table for "ALA-GLY-ALA" tripeptide
+ */
+struct Bond {
+  size_t atom1;
+  size_t atom2;
+  int8_t order;
+} bondarray[] = {
+  {0, 1, 1},
+  {1, 2, 1},
+  {1, 4, 1},
+  {2, 3, 2},
+  {2, 5, 1},
+  {5, 6, 1},
+  {6, 7, 1},
+  {7, 8, 2},
+  {7, 9, 1},
+  {9, 10, 1},
+  {10, 11, 1},
+  {10, 13, 1},
+  {11, 12, 2}
+};
+
+int main(int argc, char** argv)
+{
+  mmtf::StructureData data;
+  mmtf::GroupType* residue = nullptr;
+  const Atom * prevatom = nullptr;
+
+  // start new model
+  data.chainsPerModel.emplace_back(0);
+
+  // add atoms
+  for (const auto& atom : atomarray) {
+    data.xCoordList.emplace_back(atom.x);
+    data.yCoordList.emplace_back(atom.y);
+    data.zCoordList.emplace_back(atom.z);
+
+    const auto& chain = atom.chain;
+    int residue_number = atom.residue_number;
+
+    bool is_same_residue = false;
+    bool is_same_chain = prevatom && prevatom->chain == chain;
+
+    if (!is_same_chain) {
+      data.chainsPerModel.back() += 1;
+      data.groupsPerChain.emplace_back(0); // increment with every group
+      data.chainIdList.emplace_back(chain);
+    } else {
+      is_same_residue = prevatom && prevatom->residue_number == residue_number;
+    }
+
+    if (!is_same_residue) {
+      data.groupsPerChain.back() += 1;
+      data.groupTypeList.emplace_back(data.groupList.size());
+      data.groupIdList.emplace_back(residue_number);
+      data.groupList.emplace_back();
+      residue = &data.groupList.back();
+      residue->groupName = atom.residue_name;
+    }
+
+    residue->formalChargeList.emplace_back(atom.formal_charge);
+    residue->atomNameList.emplace_back(atom.atom_name);
+    residue->elementList.emplace_back(atom.element);
+
+    prevatom = &atom;
+  }
+
+  data.numAtoms = data.xCoordList.size();
+  data.numGroups = data.groupIdList.size();
+  data.numChains = data.chainIdList.size();
+  data.numModels = data.chainsPerModel.size();
+
+  // construct the BondAdder after adding atoms was completed
+  mmtf::BondAdder bondadder(data);
+
+  // add bonds
+  for (const auto& bond : bondarray) {
+    bondadder(bond.atom1, bond.atom2, bond.order);
+  }
+
+  std::cout << "INFO numBonds (total): " << data.numBonds << std::endl;
+  std::cout << "INFO numBonds (inter-residue): " << (data.bondAtomList.size() / 2) << std::endl;
+  std::cout << "INFO groupList.size() before compression: " << data.groupList.size() << std::endl;
+
+  mmtf::compressGroupList(data);
+
+  std::cout << "INFO groupList.size() after compression: " << data.groupList.size() << std::endl;
+
+  // write to file if filename provided
+  if (argc != 2) {
+    printf("USAGE: export <out mmtf file>\n");
+  } else {
+    mmtf::encodeToFile(data, argv[1]);
+  }
+
+  return 0;
+}
+
+// vi:sw=2:expandtab

--- a/include/mmtf/export_helpers.hpp
+++ b/include/mmtf/export_helpers.hpp
@@ -1,0 +1,140 @@
+// *************************************************************************
+//
+// Licensed under the MIT License (see accompanying LICENSE file).
+//
+// The authors of this code are: Thomas Holder
+//
+// *************************************************************************
+//
+// Helper functions and classes for exporting MMTF data.
+// See "examples/tableexport.cpp" for example usage.
+//
+// *************************************************************************
+
+#pragma once
+
+#include "errors.hpp"
+#include "structure_data.hpp"
+
+#include <algorithm>
+#include <iterator>
+#include <vector>
+
+namespace mmtf
+{
+
+/**
+ * @brief Helper class for adding bonds to a group-redundant system
+ *
+ * @pre Atoms already exist in the system
+ *
+ * @pre groupTypeList has no duplicates (otherwise adding an inter-residue
+ * bond will add it to all residues with the same group type)
+ */
+class BondAdder {
+  StructureData* m_data;
+  std::vector<int32_t> m_atom2groupType;
+  std::vector<int32_t> m_atomOffsets;
+
+public:
+  /**
+   * @param[in,out] data Consistent system with atoms
+   *
+   * @throw mmtf::EncodeError if groupTypeList has duplicates
+   */
+  BondAdder(StructureData& data)
+      : m_data(&data), m_atomOffsets(data.groupTypeList.size(), -1)
+  {
+    m_atom2groupType.reserve(data.numAtoms);
+
+    for (auto groupType : data.groupTypeList) {
+      // sanity check
+      if (m_atomOffsets[groupType] != -1) {
+        throw EncodeError("groupTypeList has duplicates");
+      }
+
+      auto atomOffset = m_atom2groupType.size();
+      auto groupSize = data.groupList[groupType].atomNameList.size();
+
+      m_atomOffsets[groupType] = atomOffset;
+      m_atom2groupType.resize(atomOffset + groupSize, groupType);
+    }
+  }
+
+  /**
+   * @brief Add one bond
+   *
+   * @param[in] atom1 Atom index 1 (zero-based)
+   * @param[in] atom2 Atom index 2 (zero-based)
+   * @param[in] order Bond order
+   *
+   * @return False if atom indices out of bounds
+   */
+  bool operator()(int32_t atom1, int32_t atom2, int8_t order)
+  {
+    if (atom1 >= m_atom2groupType.size() ||
+        atom2 >= m_atom2groupType.size())
+      return false;
+
+    if (m_atom2groupType[atom1] == m_atom2groupType[atom2]) {
+      auto groupType = m_atom2groupType[atom1];
+      auto& group = m_data->groupList[groupType];
+      group.bondAtomList.emplace_back(atom1 - m_atomOffsets[groupType]);
+      group.bondAtomList.emplace_back(atom2 - m_atomOffsets[groupType]);
+      group.bondOrderList.emplace_back(order);
+    } else {
+      m_data->bondAtomList.emplace_back(atom1);
+      m_data->bondAtomList.emplace_back(atom2);
+      m_data->bondOrderList.emplace_back(order);
+    }
+
+    ++m_data->numBonds;
+    return true;
+  }
+};
+
+/**
+ * @brief Eliminate redundant groups from groupList
+ *
+ * Modifies groupList and groupTypeList
+ *
+ * @param[in,out] data Consistent system
+ */
+inline void compressGroupList(StructureData& data)
+{
+  auto& groupList = data.groupList;
+  auto& groupTypeList = data.groupTypeList;
+
+  size_t n_old = groupList.size();
+  size_t i_free = 0;
+  std::vector<size_t> idremap(n_old, 0);
+
+  for (size_t i = 1; i < n_old; ++i) {
+    auto it = std::find(groupList.begin(), groupList.end(), groupList[i]);
+    size_t i_found = std::distance(groupList.begin(), it);
+
+    if (i_found == i) {
+      if (i_free != 0) {
+        groupList[i_free] = std::move(groupList[i]);
+        i_found = i_free;
+        ++i_free;
+      }
+    } else if (i_free == 0) {
+      i_free = i;
+    }
+
+    idremap[i] = i_found;
+  }
+
+  if (i_free != 0) {
+    groupList.resize(i_free);
+
+    for (size_t i = 0; i < groupTypeList.size(); ++i) {
+      groupTypeList[i] = idremap[groupTypeList[i]];
+    }
+  }
+}
+
+} // namespace mmtf
+
+// vi:sw=2:expandtab

--- a/include/mmtf/export_helpers.hpp
+++ b/include/mmtf/export_helpers.hpp
@@ -80,13 +80,13 @@ public:
     if (m_atom2groupType[atom1] == m_atom2groupType[atom2]) {
       int32_t groupType = m_atom2groupType[atom1];
       GroupType& group = m_data->groupList[groupType];
-      group.bondAtomList.emplace_back(atom1 - m_atomOffsets[groupType]);
-      group.bondAtomList.emplace_back(atom2 - m_atomOffsets[groupType]);
-      group.bondOrderList.emplace_back(order);
+      group.bondAtomList.push_back(atom1 - m_atomOffsets[groupType]);
+      group.bondAtomList.push_back(atom2 - m_atomOffsets[groupType]);
+      group.bondOrderList.push_back(order);
     } else {
-      m_data->bondAtomList.emplace_back(atom1);
-      m_data->bondAtomList.emplace_back(atom2);
-      m_data->bondOrderList.emplace_back(order);
+      m_data->bondAtomList.push_back(atom1);
+      m_data->bondAtomList.push_back(atom2);
+      m_data->bondOrderList.push_back(order);
     }
 
     ++m_data->numBonds;

--- a/include/mmtf/export_helpers.hpp
+++ b/include/mmtf/export_helpers.hpp
@@ -11,7 +11,8 @@
 //
 // *************************************************************************
 
-#pragma once
+#ifndef MMTF_EXPORT_HELPERS_H
+#define MMTF_EXPORT_HELPERS_H
 
 #include "errors.hpp"
 #include "structure_data.hpp"
@@ -136,5 +137,7 @@ inline void compressGroupList(StructureData& data)
 }
 
 } // namespace mmtf
+
+#endif
 
 // vi:sw=2:expandtab

--- a/tests/mmtf_tests.cpp
+++ b/tests/mmtf_tests.cpp
@@ -514,7 +514,7 @@ TEST_CASE("Test export_helpers") {
 		for (size_t j = 0; j < i; ++j) {
 			if (sd.groupTypeList[i] == sd.groupTypeList[j]) {
 				sd.groupTypeList[i] = sd.groupList.size();
-				sd.groupList.emplace_back(sd.groupList[sd.groupTypeList[j]]);
+				sd.groupList.push_back(sd.groupList[sd.groupTypeList[j]]);
 				break;
 			}
 		}

--- a/tests/mmtf_tests.cpp
+++ b/tests/mmtf_tests.cpp
@@ -8,6 +8,7 @@
 #include "catch.hpp"
 
 #include <mmtf.hpp>
+#include <mmtf/export_helpers.hpp>
 
 
 // NOTE!!! Margin is set to 0.00001
@@ -495,6 +496,85 @@ TEST_CASE("Test bondOrderList vs bondAtomList") {
 	}
 }
 
+TEST_CASE("Test export_helpers") {
+	std::string working_mmtf = "../mmtf_spec/test-suite/mmtf/3NJW.mmtf";
+	mmtf::StructureData sd;
+	mmtf::decodeFromFile(sd, working_mmtf);
+	size_t numbonds_ref = sd.numBonds;
+	std::vector<int32_t> bonddata;
+
+	// test requirement: groupTypeList has duplicates
+	REQUIRE(sd.groupTypeList.size() != sd.groupList.size());
+
+	// must throw with duplicates
+	REQUIRE_THROWS_AS(mmtf::BondAdder(sd), mmtf::EncodeError);
+
+	// make groupTypeList non-duplicate
+	for (size_t i = 1; i < sd.groupTypeList.size(); ++i) {
+		for (size_t j = 0; j < i; ++j) {
+			if (sd.groupTypeList[i] == sd.groupTypeList[j]) {
+				sd.groupTypeList[i] = sd.groupList.size();
+				sd.groupList.emplace_back(sd.groupList[sd.groupTypeList[j]]);
+				break;
+			}
+		}
+	}
+
+	// test assert: groupTypeList has no duplicates anymore
+	REQUIRE(sd.groupTypeList.size() == sd.groupList.size());
+
+	// remove group bonds
+	size_t offset = 0;
+	for (auto groupType : sd.groupTypeList) {
+		auto & group = sd.groupList[groupType];
+		for (size_t i = 0; i < group.bondOrderList.size(); ++i) {
+			bonddata.push_back(group.bondAtomList[i * 2] + offset);
+			bonddata.push_back(group.bondAtomList[i * 2 + 1] + offset);
+			bonddata.push_back(group.bondOrderList[i]);
+			--sd.numBonds;
+		}
+		offset += group.atomNameList.size();
+		group.bondAtomList.clear();
+		group.bondOrderList.clear();
+	}
+
+	// remove global bonds
+	for (size_t i = 0; i < sd.bondOrderList.size(); ++i) {
+		bonddata.push_back(sd.bondAtomList[i * 2]);
+		bonddata.push_back(sd.bondAtomList[i * 2 + 1]);
+		bonddata.push_back(sd.bondOrderList[i]);
+		--sd.numBonds;
+	}
+	sd.bondAtomList.clear();
+	sd.bondOrderList.clear();
+
+	// test assert: all bonds have been transferred to `bonddata`
+	REQUIRE(bonddata.size() == numbonds_ref * 3);
+	REQUIRE(sd.numBonds == 0);
+	REQUIRE(sd.hasConsistentData(true));
+
+	// re-add bonds
+	mmtf::BondAdder bondadder(sd);
+	for (size_t i = 0; i < bonddata.size(); i += 3) {
+		REQUIRE(bondadder(bonddata[i], bonddata[i + 1], bonddata[i + 2]));
+	}
+	REQUIRE(sd.numBonds == numbonds_ref);
+	REQUIRE(sd.hasConsistentData(true));
+
+	// re-compress groupTypeList
+	mmtf::compressGroupList(sd);
+	REQUIRE(sd.groupTypeList.size() != sd.groupList.size());
+	REQUIRE(sd.hasConsistentData(true));
+
+	// compare with original data
+	mmtf::StructureData sd_ref;
+	mmtf::decodeFromFile(sd_ref, working_mmtf);
+	REQUIRE(sd_ref.bondAtomList == sd.bondAtomList);
+	REQUIRE(sd_ref.bondOrderList == sd.bondOrderList);
+	REQUIRE(sd_ref.groupTypeList == sd.groupTypeList);
+	REQUIRE(sd_ref.groupList == sd.groupList);
+}
+
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 
@@ -509,3 +589,5 @@ int main(int argc, char* argv[]) {
     return Catch::Session().run(argc, argv);
 }
 #endif
+
+// vi:noexpandtab:sw=4:ts=4


### PR DESCRIPTION
This pull request adds two helpers for molecule export from tabular data:

* `mmtf::BondAdder` for efficient bond adding
* `mmtf::compressGroupList` for creating a non-redundant `groupList`

We implemented those for MMTF export in PyMOL, but since the code is not PyMOL specific, we'd like to contribute it directly to the `mmtf-cpp` library.

See [examples/tableexport.cpp](https://github.com/rcsb/mmtf-cpp/blob/export_helpers/examples/tableexport.cpp) for an example how to use these helpers.