### PR TITLE
Add installer stage to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ project(mmtf-cpp VERSION 1.0.0 LANGUAGES CXX)
 option(mmtf_build_local "Use the submodule dependencies for building" OFF)
 option(mmtf_build_examples "Build the examples" OFF)
 
+option(mmtf_install_system "Install mmtf to ${CMAKE_INSTALL_PREFIX}/include" OFF)
+
 add_library(MMTFcpp INTERFACE)
 target_compile_features(MMTFcpp INTERFACE cxx_auto_type)
 
@@ -38,4 +40,11 @@ endif()
 
 if (mmtf_build_examples)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples)
+endif()
+
+if (mmtf_install_system)
+    install(
+        DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+        DESTINATION  "/include"
+        FILES_MATCHING PATTERN "*.hpp")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,6 @@ project(mmtf-cpp VERSION 1.0.0 LANGUAGES CXX)
 option(mmtf_build_local "Use the submodule dependencies for building" OFF)
 option(mmtf_build_examples "Build the examples" OFF)
 
-option(mmtf_install_system "Install mmtf to ${CMAKE_INSTALL_PREFIX}/include" OFF)
-
 add_library(MMTFcpp INTERFACE)
 target_compile_features(MMTFcpp INTERFACE cxx_auto_type)
 
@@ -42,9 +40,7 @@ if (mmtf_build_examples)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/examples)
 endif()
 
-if (mmtf_install_system)
-    install(
-        DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
-        DESTINATION  "/include"
-        FILES_MATCHING PATTERN "*.hpp")
-endif()
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+    DESTINATION  "/include"
+    FILES_MATCHING PATTERN "*.hpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,5 +42,5 @@ endif()
 
 install(
     DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
-    DESTINATION  "/include"
+    DESTINATION  "include"
     FILES_MATCHING PATTERN "*.hpp")

--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ To do so:
 ```bash
 mkdir build
 cd build
-cmake -G Ninja -Dmmtf_install_system=ON ..
+cmake -G Ninja ..
 sudo ninja install
 ```
 
 `cmake` automatically sets the installation directory to `/usr/local/include`, if you want to install it to another `*include/` directory
 run `cmake` with the command:
 ```bash
-cmake -G Ninja -Dmmtf_install_system=ON -DCMAKE_INSTALL_PREFIX=/home/me/local ..
+cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/home/me/local ..
 ```
 Be aware that `/include` is added to the end of `DCMAKE_INSTALL_PREFIX` and that is where your files are installed (i.e. the above would install at `/home/me/local/include/`).
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ run `cmake` with the command:
 ```bash
 cmake -G Ninja -Dmmtf_install_system=ON -DCMAKE_INSTALL_PREFIX=/home/me/local ..
 ```
-Be aware that `/include` is added to the end of `DCMAKE_INSTALL_PREFIX` and that is where your files are installed. ie the above would install at `/home/me/local/include/`
+Be aware that `/include` is added to the end of `DCMAKE_INSTALL_PREFIX` and that is where your files are installed (i.e. the above would install at `/home/me/local/include/`).
 
 
 ## Examples and tests

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Here, `<MSGPACK_INCLUDE_PATH>` and `<MMTF_INCLUDE_PATH>` are the paths to the
 For your more complicated projects, a `CMakeLists.txt` is included for you.
 
 ## Installation
-This is a header only project, there is no compilation necessary.  If you want to use it in your project you can
+This is a header only project and hence there is no compilation necessary. If you want to use it in your project you can
 download this repo and add `-I/full/path/to/mmtf-cpp/include` to your `g++` or `clang++` command.  
 *REMINDER* This project depends on [msgpack-c](https://github.com/msgpack/msgpack-c), you must also install that to your system
 or add the `msgpack-c` include directory to your g++ command as well.  

--- a/README.md
+++ b/README.md
@@ -41,6 +41,30 @@ Here, `<MSGPACK_INCLUDE_PATH>` and `<MMTF_INCLUDE_PATH>` are the paths to the
 
 For your more complicated projects, a `CMakeLists.txt` is included for you.
 
+## Installation
+This is a header only project, there is no compilation necessary.  If you want to use it in your project you can
+download this repo and add `-I/full/path/to/mmtf-cpp/include` to your `g++` or `clang++` command.  
+*REMINDER* This project depends on [msgpack-c](https://github.com/msgpack/msgpack-c), you must also install that to your system
+or add the `msgpack-c` include directory to your g++ command as well.  
+
+You can also perform a system wide installation with `cmake` and `ninja` (or `make`).  This is generally how you would
+install something for a `Docker` image.
+to do so:
+```bash
+mkdir build
+cd build
+cmake -G Ninja -Dmmtf_install_system=ON ..
+sudo ninja install
+```
+
+`cmake` automatically sets the installation directory to `/usr/local/include`, if you want to install it to another `*include/` directory
+run `cmake` with the command:
+```bash
+cmake -G Ninja -Dmmtf_install_system=ON -DCMAKE_INSTALL_PREFIX=/home/me/local ..
+```
+Be aware that `/include` is added to the end of `DCMAKE_INSTALL_PREFIX` and that is where your files are installed. ie the above would install at `/home/me/local/include/`
+
+
 ## Examples and tests
 
 To build the tests + examples we recommend using the following lines:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ or add the `msgpack-c` include directory to your g++ command as well.
 
 You can also perform a system wide installation with `cmake` and `ninja` (or `make`).  This is generally how you would
 install something for a `Docker` image.
-to do so:
+To do so:
 ```bash
 mkdir build
 cd build

--- a/README.md
+++ b/README.md
@@ -42,13 +42,7 @@ Here, `<MSGPACK_INCLUDE_PATH>` and `<MMTF_INCLUDE_PATH>` are the paths to the
 For your more complicated projects, a `CMakeLists.txt` is included for you.
 
 ## Installation
-This is a header only project and hence there is no compilation necessary. If you want to use it in your project you can
-download this repo and add `-I/full/path/to/mmtf-cpp/include` to your `g++` or `clang++` command.  
-*REMINDER* This project depends on [msgpack-c](https://github.com/msgpack/msgpack-c), you must also install that to your system
-or add the `msgpack-c` include directory to your g++ command as well.  
-
-You can also perform a system wide installation with `cmake` and `ninja` (or `make`).  This is generally how you would
-install something for a `Docker` image.
+You can also perform a system wide installation with `cmake` and `ninja` (or `make`).
 To do so:
 ```bash
 mkdir build


### PR DESCRIPTION
Detailed in README.md, but now you can install with:
cmake -G Ninja -Dmmtf_install_system=ON ..
ninja install

and mmtf-cpp will installed to /usr/local/include