### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## Unreleased
+### Added
+- Initial release including decoder and encoder for the
+  [MMTF specification 1.0](https://github.com/rcsb/mmtf/blob/v1.0/spec.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## v1.0.0
 ### Added
 - Initial release including decoder and encoder for the
   [MMTF specification 1.0](https://github.com/rcsb/mmtf/blob/v1.0/spec.md).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+<!--- Batch image URLs generated at https://shields.io -->
+<!--- Wait for release to uncomment
+[![Release](https://img.shields.io/github/release/rcsb/mmtf-cpp.svg?style=flat)](https://github.com/rcsb/mmtf-cpp/releases)
+-->
+[![License](https://img.shields.io/github/license/rcsb/mmtf-cpp.svg?style=flat)](https://github.com/rcsb/mmtf-cpp/blob/master/LICENSE)
+[![Build Status (Travis)](https://img.shields.io/travis/rcsb/mmtf-cpp/master.svg?style=flat)](https://travis-ci.org/rcsb/mmtf-cpp)
+[![Build Status (AppVeyor)](https://img.shields.io/appveyor/ci/rcsb/mmtf-cpp/master.svg?style=flat)](https://ci.appveyor.com/project/rcsb/mmtf-cpp)
 
 The <b>m</b>acro<b>m</b>olecular <b>t</b>ransmission <b>f</b>ormat
 ([MMTF](http://mmtf.rcsb.org)) is a binary encoding of biological structures.


### PR DESCRIPTION
I did some checks on this repo and I think it deserves a stable release tag before we add experimental features for MMTF's 1.1 specs.

Any objections for releasing it as "v1.0.0"? If not, I would do this early next week before looking at the other PRs.

This should close #21 and allow for a solution in #24 since any git tag enables the source code to be downloaded without git-stuff like submodules via a stable URL.