### PR TITLE
Updated Travis CI and added example-test with C++03

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,10 +55,5 @@ script:
   - $CMAKE_CONFIGURE cmake $CMAKE_ARGS $CMAKE_EXTRA ..
   - make -j2
   - ctest -j2 --output-on-failure
-  # Test compilation of example code
-  - cd $TRAVIS_BUILD_DIR
-  - cd examples
-  - echo $CXX03
-  - $CXX -I"../msgpack-c/include" -I"../include" $CXX03 -O2 -o read_and_write read_and_write.cpp
-  - ./read_and_write ../mmtf_spec/test-suite/mmtf/3NJW.mmtf test.mmtf
+  - bash $TRAVIS_BUILD_DIR/ci/travis-test-example.sh
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,8 @@ matrix:
       addons: *linux32
     - os: osx
       compiler: clang
-      osx_image: xcode7.3
     - os: osx
       compiler: gcc
-      osx_image: xcode7.3
       addons: *osx_gcc
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,10 @@ script:
   - $CMAKE_CONFIGURE cmake $CMAKE_ARGS $CMAKE_EXTRA ..
   - make -j2
   - ctest -j2 --output-on-failure
+  # Test compilation of example code
+  - cd $TRAVIS_BUILD_DIR
+  - cd examples
+  - echo $CXX03
+  - $CXX -I"../msgpack-c/include" -I"../include" $CXX03 -O2 -o read_and_write read_and_write.cpp
+  - ./read_and_write ../mmtf_spec/test-suite/mmtf/3NJW.mmtf test.mmtf
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ osx_gcc_addons:
     addons: &osx_gcc
       homebrew:
         packages:
-        - gcc@5
+        - gcc@6
 
 # Set empty values for allow_failures to work
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,12 @@ linux32_addons:
         - linux-libc-dev:i386
         - libc6-dev-i386
 
+osx_gcc_addons:
+    addons: &osx_gcc
+      homebrew:
+        packages:
+        - gcc@5
+
 # Set empty values for allow_failures to work
 env:
 
@@ -41,6 +47,7 @@ matrix:
     - os: osx
       compiler: gcc
       osx_image: xcode7.3
+      addons: *osx_gcc
 
 before_install:
   # Setting environement

--- a/ci/setup-travis.sh
+++ b/ci/setup-travis.sh
@@ -32,9 +32,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 fi
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    brew update
     if [[ "$CC" == "gcc" ]]; then
-        brew install gcc@5
         export CC=gcc-5
         export CXX=g++-5
     fi

--- a/ci/setup-travis.sh
+++ b/ci/setup-travis.sh
@@ -33,15 +33,6 @@ fi
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     if [[ "$CC" == "gcc" ]]; then
-        echo "--------------------------------"
-        echo $CXX
-        which gcc
-        which g++
-        ls -l $(which g++)
-        echo "--------------------------------"
-        which g++-6
-        ls -l $(which g++-6)
-        echo "--------------------------------"
         export CC=gcc-6
         export CXX=g++-6
     fi

--- a/ci/setup-travis.sh
+++ b/ci/setup-travis.sh
@@ -28,7 +28,6 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     if [[ "$CC" == "gcc" ]]; then
         export CC=gcc-4.8
         export CXX=g++-4.8
-        export CXX03=-std=c++03
     fi
 fi
 

--- a/ci/setup-travis.sh
+++ b/ci/setup-travis.sh
@@ -33,8 +33,17 @@ fi
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     if [[ "$CC" == "gcc" ]]; then
-        export CC=gcc-5
-        export CXX=g++-5
+        echo "--------------------------------"
+        echo $CXX
+        which gcc
+        which g++
+        ls -l $(which g++)
+        echo "--------------------------------"
+        which g++-6
+        ls -l $(which g++-6)
+        echo "--------------------------------"
+        export CC=gcc-6
+        export CXX=g++-6
     fi
 fi
 

--- a/ci/setup-travis.sh
+++ b/ci/setup-travis.sh
@@ -28,6 +28,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     if [[ "$CC" == "gcc" ]]; then
         export CC=gcc-4.8
         export CXX=g++-4.8
+        export CXX03=-std=c++03
     fi
 fi
 

--- a/ci/travis-test-example.sh
+++ b/ci/travis-test-example.sh
@@ -14,8 +14,9 @@ if [ -z "$EMSCRIPTEN" ]; then
          -o read_and_write read_and_write.cpp
     ./read_and_write ../mmtf_spec/test-suite/mmtf/3NJW.mmtf test.mmtf
 else
-    # Skip running code with emscripten (would need file access)
-    # -> just do .js compilation here
+    # Cannot do C++03 here and need to embed input file for running it with node
+    cp ../mmtf_spec/test-suite/mmtf/3NJW.mmtf .
     $CXX -I"../msgpack-c/include" -I"../include" -O2 \
-         -o read_and_write.js read_and_write.cpp
+         -o read_and_write.js read_and_write.cpp --embed-file 3NJW.mmtf
+    node read_and_write.js 3NJW.mmtf test.mmtf
 fi

--- a/ci/travis-test-example.sh
+++ b/ci/travis-test-example.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Test compilation of example code using C++03 if possible
+# -> only expected to work in Linux or Mac with CXX set to g++ or clang++
+# -> expects TRAVIS_BUILD_DIR, EMSCRIPTEN, CXX to be set
+
+# abort on error and exit with proper exit code
+set -e
+# test example
+cd $TRAVIS_BUILD_DIR/examples
+if [[ "$EMSCRIPTEN" == "ON" ]]; then
+    # Skip running code with emscripten (would need file access)
+    # -> just do .js compilation here
+    $CXX -I"../msgpack-c/include" -I"../include" -O2 \
+         -o read_and_write.js read_and_write.cpp
+else
+    # Compile with C++03 forced
+    $CXX -I"../msgpack-c/include" -I"../include" -std=c++03 -O2 \
+         -o read_and_write read_and_write.cpp
+    ./read_and_write ../mmtf_spec/test-suite/mmtf/3NJW.mmtf test.mmtf
+fi

--- a/ci/travis-test-example.sh
+++ b/ci/travis-test-example.sh
@@ -8,14 +8,14 @@
 set -e
 # test example
 cd $TRAVIS_BUILD_DIR/examples
-if [[ "$EMSCRIPTEN" == "ON" ]]; then
-    # Skip running code with emscripten (would need file access)
-    # -> just do .js compilation here
-    $CXX -I"../msgpack-c/include" -I"../include" -O2 \
-         -o read_and_write.js read_and_write.cpp
-else
+if [ -z "$EMSCRIPTEN" ]; then
     # Compile with C++03 forced
     $CXX -I"../msgpack-c/include" -I"../include" -std=c++03 -O2 \
          -o read_and_write read_and_write.cpp
     ./read_and_write ../mmtf_spec/test-suite/mmtf/3NJW.mmtf test.mmtf
+else
+    # Skip running code with emscripten (would need file access)
+    # -> just do .js compilation here
+    $CXX -I"../msgpack-c/include" -I"../include" -O2 \
+         -o read_and_write.js read_and_write.cpp
 fi

--- a/include/mmtf/structure_data.hpp
+++ b/include/mmtf/structure_data.hpp
@@ -440,12 +440,10 @@ bool is_polymer(const unsigned int chain_index,
               || entity_list[i].type == "POLYMER");
     }
   }
-  // std::stringstream err;
-  // err << "'is_polymer' unable to find chain_index: " << chain_index
-  //     << " in entity list";
-  // throw DecodeError(err.str());
-  throw DecodeError("'is_polymer' unable to find chain_index: "
-                    + std::to_string(chain_index) + " in entity list");
+  std::stringstream err;
+  err << "'is_polymer' unable to find chain_index: " << chain_index
+      << " in entity list";
+  throw DecodeError(err.str());
 }
 
 bool is_hetatm(const char* type) {

--- a/include/mmtf/structure_data.hpp
+++ b/include/mmtf/structure_data.hpp
@@ -440,10 +440,12 @@ bool is_polymer(const unsigned int chain_index,
               || entity_list[i].type == "POLYMER");
     }
   }
-  std::stringstream err;
-  err << "'is_polymer' unable to find chain_index: " << chain_index
-      << " in entity list";
-  throw DecodeError(err.str());
+  // std::stringstream err;
+  // err << "'is_polymer' unable to find chain_index: " << chain_index
+  //     << " in entity list";
+  // throw DecodeError(err.str());
+  throw DecodeError("'is_polymer' unable to find chain_index: "
+                    + std::to_string(chain_index) + " in entity list");
 }
 
 bool is_hetatm(const char* type) {


### PR DESCRIPTION
I updated the Travis CI since I had noticed some issues while reviewing the last PR.

I included a new test which compiles and runs one of the example codes (read and write) with C++03 wherever possible. I didn't manage to write a script to run it with EMSCRIPTEN but I guess that's ok. The problem so far was that Catch2 requires C++11 and hence cmake automatically switches to C++11. As a result, it was possible for C++11 code to get into the main code without CI noticing it. The new test will lead to failures in such a case (see https://travis-ci.org/gtauriello/mmtf-cpp/builds/506419291 and ignore the EMSCRIPTEN failure there). The Linux tests (apart from EMSCRIPTEN) and macOS with gcc would now fail (macOS clang seems to ignore the C++03 request).

In the process I saw that we use an old macOS image and a deprecated way to install packages (see https://docs.travis-ci.com/user/reference/osx/#homebrew). I updated the Travis config accordingly and updated the GCC version used since Homebrew's gcc-5 has issues with recent macOS versions.