### PR TITLE
added benchmark section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ compiled via:
 g++ -Ofast -Immtf/include  -Imsgpack/include  decode_all_mmtf.cpp
 ```
 
-We are able to load 153,987 mmtf files (current size of the pdb) from an SSD in (n=4)
+We are able to load 153,987 mmtf files (current size of the pdb) or  14.3GB from an SSD in (n=4)
 * 215.0 seconds
 * 210.9 seconds
 * 209.3 seconds

--- a/README.md
+++ b/README.md
@@ -101,8 +101,6 @@ Example codes:
 
 using the following simple code:
 ```cpp
-#include <string>
-#include <iostream>
 #include <mmtf.hpp>
 
 
@@ -110,7 +108,7 @@ int main(int argc, char** argv)
 {
         for (int i=1; i<argc; ++i) {
                 mmtf::StructureData sd;
-                mmtf::decodeFromFile(sd, std::string(argv[i]));
+                mmtf::decodeFromFile(sd, argv[i]);
         }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -97,6 +97,34 @@ Example codes:
 ./examples/print_as_pdb ../mmtf_spec/test-suite/mmtf/173D.mmtf
 ```
 
+## Benchmark
+
+using the following simple code:
+```cpp
+#include <string>
+#include <iostream>
+#include <mmtf.hpp>
+
+
+int main(int argc, char** argv)
+{
+        for (int i=1; i<argc; ++i) {
+                mmtf::StructureData sd;
+                mmtf::decodeFromFile(sd, std::string(argv[i]));
+        }
+}
+```
+compiled via:
+```
+g++ -Ofast -Immtf/include  -Imsgpack/include  decode_all_mmtf.cpp
+```
+
+We are able to load 153,987 mmtf files (current size of the pdb) from an SSD in (n=4)
+* 215.0 seconds
+* 210.9 seconds
+* 209.3 seconds
+* 210.0 seconds
+
 ## Code documentation
 
 You can generate a [doxygen](http://www.doxygen.org) based documentation of the

--- a/README.md
+++ b/README.md
@@ -117,11 +117,7 @@ compiled via:
 g++ -Ofast -Immtf/include  -Imsgpack/include  decode_all_mmtf.cpp
 ```
 
-We are able to load 153,987 mmtf files (current size of the pdb) or  14.3GB from an SSD in (n=4)
-* 215.0 seconds
-* 210.9 seconds
-* 209.3 seconds
-* 210.0 seconds
+We are able to load 153,987 mmtf files (current size of the pdb) or 14.3GB from an SSD in 211.3 seconds (averaged over 4 runs with minimal differences between the runs).
 
 ## Code documentation
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Example codes:
 
 ## Benchmark
 
-using the following simple code:
+Using the following simple code:
 ```cpp
 #include <mmtf.hpp>
 


### PR DESCRIPTION
Making slides and wanted to report some benchmarks
@pwrose if you're interested

 We are able to load 153,987 mmtf files (current size of the pdb) from an SSD in (n=4)
* 215.0 seconds
* 210.9 seconds
* 209.3 seconds
* 210.0 seconds