### PR TITLE
binaryEncoder more const correctness

### DIFF
--- a/include/mmtf/binary_decoder.hpp
+++ b/include/mmtf/binary_decoder.hpp
@@ -34,9 +34,23 @@ public:
      * Reads out binary header to prepare for call of decode.
      * @param[in]  obj  Object to decode.
      * @param[in]  key  Key used to report errors.
+     * @warning This uses a pointer to the data of obj. obj must stay alive
+     *  while this instance exists or it will result in undefined behavior.
      * @throw mmtf::DecodeError if obj is not a binary or is too short.
      */
     BinaryDecoder(const msgpack::object& obj,
+                  const std::string& key = "UNNAMED_BINARY");
+
+    /**
+     * @brief Initialize object given a msgpack binary string.
+     * Reads out binary header to prepare for call of decode.
+     * @param[in]  str  Object to decode.
+     * @param[in]  key  Key used to report errors.
+     * @warning This uses a pointer to the data of str. str must stay alive
+     *  while this instance exists or it will result in undefined behavior.
+     * @throw mmtf::DecodeError if obj is not a binary or is too short.
+     */
+    BinaryDecoder(const std::string& str,
                   const std::string& key = "UNNAMED_BINARY");
 
     /**
@@ -55,7 +69,7 @@ public:
      * @throw mmtf::DecodeError if we fail to decode.
      */
     template<typename T>
-    void decode(T& target);
+    void decode(T& target) const;
 
 private:
     // for error reporting
@@ -67,42 +81,47 @@ private:
     const char* encodedData_;
     uint32_t encodedDataLength_;  // max. size for binary is 2^32 - 1
 
+    // helper function for constructors
+    void
+    initFromData(const char * str_data,
+                 const std::size_t len);
+
     // check length consistency (throws)
-    void checkLength_(int32_t exp_length);
+    void checkLength_(int32_t exp_length) const;
     // check if binary data is divisible by x (throws)
-    void checkDivisibleBy_(int32_t item_size);
+    void checkDivisibleBy_(int32_t item_size) const;
 
     // byte decoders
-    void decodeFromBytes_(std::vector<float>& output);
-    void decodeFromBytes_(std::vector<int8_t>& output);
-    void decodeFromBytes_(std::vector<int16_t>& output);
-    void decodeFromBytes_(std::vector<int32_t>& output);
+    void decodeFromBytes_(std::vector<float>& output) const;
+    void decodeFromBytes_(std::vector<int8_t>& output) const;
+    void decodeFromBytes_(std::vector<int16_t>& output) const;
+    void decodeFromBytes_(std::vector<int32_t>& output) const;
     // special one: decode to vector of strings
-    void decodeFromBytes_(std::vector<std::string>& output);
+    void decodeFromBytes_(std::vector<std::string>& output) const;
 
     // run length decoding
     // -> Int and IntOut can be any integer types
     // -> Int values are blindly converted to IntOut
     template<typename Int, typename IntOut>
     void runLengthDecode_(const std::vector<Int>& input,
-                          std::vector<IntOut>& output);
+                          std::vector<IntOut>& output) const;
 
     // delta decoding -> Int can be any integer type
     template<typename Int>
-    void deltaDecode_(const std::vector<Int>& input, std::vector<Int>& output);
+    void deltaDecode_(const std::vector<Int>& input, std::vector<Int>& output) const;
     // variant doing it in-place
     template<typename Int>
-    void deltaDecode_(std::vector<Int>& in_out);
+    void deltaDecode_(std::vector<Int>& in_out) const;
 
     // recursive indexing decode -> SmallInt must be smaller than Int
     template<typename SmallInt, typename Int>
     void recursiveIndexDecode_(const std::vector<SmallInt>& input,
-                               std::vector<Int>& output);
+                               std::vector<Int>& output) const;
 
     // decode integer to float -> Int can be any integer type
     template<typename Int>
-    void decodeDivide_(const std::vector<Int>& input, float divisor,
-                       std::vector<float>& output);
+    void decodeDivide_(const std::vector<Int>& input, float const divisor,
+                       std::vector<float>& output) const;
 };
 
 // *************************************************************************
@@ -160,6 +179,16 @@ void arrayCopyBigendian2(void* dst, const char* src, size_t n) {
 
 } // anon ns
 
+
+// note this does not set key_, you must set it in ctor
+inline void BinaryDecoder::initFromData(const char * bytes, std::size_t const len) {
+    assignBigendian4(&strategy_, bytes);
+    assignBigendian4(&length_, bytes + 4);
+    assignBigendian4(&parameter_, bytes + 8);
+    encodedData_ = bytes + 12;
+    encodedDataLength_ = len - 12;
+}
+
 inline BinaryDecoder::BinaryDecoder(const msgpack::object& obj,
                                     const std::string& key)
                                    : key_(key) {
@@ -172,23 +201,22 @@ inline BinaryDecoder::BinaryDecoder(const msgpack::object& obj,
         err << "The '" + key + "' entry is too short " << obj.via.bin.size;
         throw DecodeError(err.str());
     }
-    // get data (encoded data is only pointed to and not parsed here)
-    const char* bytes = obj.via.bin.ptr;
+    this->initFromData(obj.via.bin.ptr, obj.via.bin.size);
+}
 
-    assignBigendian4(&strategy_, bytes);
-    assignBigendian4(&length_, bytes + 4);
-    assignBigendian4(&parameter_, bytes + 8);
-    encodedData_ = bytes + 12;
-    encodedDataLength_ = obj.via.bin.size - 12;
+inline BinaryDecoder::BinaryDecoder(const std::string& str,
+                                    const std::string& key)
+                                   : key_(key) {
+    this->initFromData(str.data(), str.size());
 }
 
 template<typename T>
-void BinaryDecoder::decode(T& target) {
+void BinaryDecoder::decode(T&) const {
     throw mmtf::DecodeError("Invalid target type for binary '" + key_ + "'");
 }
 
 template<>
-inline void BinaryDecoder::decode(std::vector<float>& output) {
+inline void BinaryDecoder::decode(std::vector<float>& output) const {
 
     // check strategy to parse
     switch (strategy_) {
@@ -248,7 +276,7 @@ inline void BinaryDecoder::decode(std::vector<float>& output) {
 }
 
 template<>
-inline void BinaryDecoder::decode(std::vector<int8_t>& output) {
+inline void BinaryDecoder::decode(std::vector<int8_t>& output) const {
 
     // check strategy to parse
     switch (strategy_) {
@@ -275,7 +303,7 @@ inline void BinaryDecoder::decode(std::vector<int8_t>& output) {
 }
 
 template<>
-inline void BinaryDecoder::decode(std::vector<int16_t>& output) {
+inline void BinaryDecoder::decode(std::vector<int16_t>& output) const {
 
     // check strategy to parse
     switch (strategy_) {
@@ -296,7 +324,7 @@ inline void BinaryDecoder::decode(std::vector<int16_t>& output) {
 }
 
 template<>
-inline void BinaryDecoder::decode(std::vector<int32_t>& output) {
+inline void BinaryDecoder::decode(std::vector<int32_t>& output) const {
 
     // check strategy to parse
     switch (strategy_) {
@@ -342,7 +370,7 @@ inline void BinaryDecoder::decode(std::vector<int32_t>& output) {
 }
 
 template<>
-inline void BinaryDecoder::decode(std::vector<std::string>& output) {
+inline void BinaryDecoder::decode(std::vector<std::string>& output) const {
 
     // check strategy to parse
     switch (strategy_) {
@@ -363,7 +391,7 @@ inline void BinaryDecoder::decode(std::vector<std::string>& output) {
 }
 
 template<>
-inline void BinaryDecoder::decode(std::vector<char>& output) {
+inline void BinaryDecoder::decode(std::vector<char>& output) const {
 
     // check strategy to parse
     switch (strategy_) {
@@ -386,7 +414,7 @@ inline void BinaryDecoder::decode(std::vector<char>& output) {
 }
 
 // checks
-inline void BinaryDecoder::checkLength_(int32_t exp_length) {
+inline void BinaryDecoder::checkLength_(int32_t exp_length) const {
     if (length_ != exp_length) {
         std::stringstream err;
         err << "Length mismatch for binary '" + key_ + "': "
@@ -395,7 +423,7 @@ inline void BinaryDecoder::checkLength_(int32_t exp_length) {
     }
 }
 
-inline void BinaryDecoder::checkDivisibleBy_(int32_t item_size) {
+inline void BinaryDecoder::checkDivisibleBy_(int32_t item_size) const {
     if (encodedDataLength_ % item_size != 0) {
         std::stringstream err;
         err << "Binary length of '" + key_ + "': "
@@ -405,7 +433,7 @@ inline void BinaryDecoder::checkDivisibleBy_(int32_t item_size) {
 }
 
 // byte decoders
-inline void BinaryDecoder::decodeFromBytes_(std::vector<float>& output) {
+inline void BinaryDecoder::decodeFromBytes_(std::vector<float>& output) const {
     checkDivisibleBy_(4);
     // prepare memory
     output.resize(encodedDataLength_ / 4);
@@ -414,7 +442,7 @@ inline void BinaryDecoder::decodeFromBytes_(std::vector<float>& output) {
         arrayCopyBigendian4(&output[0], encodedData_, encodedDataLength_);
     }
 }
-inline void BinaryDecoder::decodeFromBytes_(std::vector<int8_t>& output) {
+inline void BinaryDecoder::decodeFromBytes_(std::vector<int8_t>& output) const {
     // prepare memory
     output.resize(encodedDataLength_);
     // get data
@@ -422,7 +450,7 @@ inline void BinaryDecoder::decodeFromBytes_(std::vector<int8_t>& output) {
         memcpy(&output[0], encodedData_, encodedDataLength_);
     }
 }
-inline void BinaryDecoder::decodeFromBytes_(std::vector<int16_t>& output) {
+inline void BinaryDecoder::decodeFromBytes_(std::vector<int16_t>& output) const {
     checkDivisibleBy_(2);
     // prepare memory
     output.resize(encodedDataLength_ / 2);
@@ -431,7 +459,7 @@ inline void BinaryDecoder::decodeFromBytes_(std::vector<int16_t>& output) {
         arrayCopyBigendian2(&output[0], encodedData_, encodedDataLength_);
     }
 }
-inline void BinaryDecoder::decodeFromBytes_(std::vector<int32_t>& output) {
+inline void BinaryDecoder::decodeFromBytes_(std::vector<int32_t>& output) const {
     checkDivisibleBy_(4);
     // prepare memory
     output.resize(encodedDataLength_ / 4);
@@ -441,7 +469,7 @@ inline void BinaryDecoder::decodeFromBytes_(std::vector<int32_t>& output) {
     }
 }
 // special one: decode to vector of strings
-inline void BinaryDecoder::decodeFromBytes_(std::vector<std::string>& output) {
+inline void BinaryDecoder::decodeFromBytes_(std::vector<std::string>& output) const {
     char NULL_BYTE = 0x00;
     // check parameter
     const int32_t str_len = parameter_;
@@ -458,7 +486,7 @@ inline void BinaryDecoder::decodeFromBytes_(std::vector<std::string>& output) {
 // run length decoding
 template<typename Int, typename IntOut>
 void BinaryDecoder::runLengthDecode_(const std::vector<Int>& input,
-                      std::vector<IntOut>& output) {
+                      std::vector<IntOut>& output) const {
     // we work with pairs of numbers
     checkDivisibleBy_(2);
     // find out size of resulting vector (for speed)
@@ -482,7 +510,7 @@ void BinaryDecoder::runLengthDecode_(const std::vector<Int>& input,
 // delta decoding
 template<typename Int>
 void BinaryDecoder::deltaDecode_(const std::vector<Int>& input,
-                                 std::vector<Int>& output) {
+                                 std::vector<Int>& output) const {
     // reserve space (for speed)
     output.clear();
     if (input.empty()) return; // ensure we have some values
@@ -494,7 +522,7 @@ void BinaryDecoder::deltaDecode_(const std::vector<Int>& input,
     }
 }
 template<typename Int>
-void BinaryDecoder::deltaDecode_(std::vector<Int>& in_out) {
+void BinaryDecoder::deltaDecode_(std::vector<Int>& in_out) const {
     for (size_t i = 1; i < in_out.size(); ++i) {
         in_out[i] = in_out[i - 1] + in_out[i];
     }
@@ -503,7 +531,7 @@ void BinaryDecoder::deltaDecode_(std::vector<Int>& in_out) {
 // recursive indexing decode
 template<typename SmallInt, typename Int>
 void BinaryDecoder::recursiveIndexDecode_(const std::vector<SmallInt>& input,
-                                          std::vector<Int>& output) {
+                                          std::vector<Int>& output) const {
     // get limits
     const SmallInt min_int = std::numeric_limits<SmallInt>::min();
     const SmallInt max_int = std::numeric_limits<SmallInt>::max();
@@ -528,8 +556,8 @@ void BinaryDecoder::recursiveIndexDecode_(const std::vector<SmallInt>& input,
 
 // decode integer to float
 template<typename Int>
-void BinaryDecoder::decodeDivide_(const std::vector<Int>& input, float divisor,
-                                  std::vector<float>& output) {
+void BinaryDecoder::decodeDivide_(const std::vector<Int>& input, float const divisor,
+                                  std::vector<float>& output) const {
     // reserve space and get inverted divisor (for speed)
     output.clear();
     output.reserve(input.size());

--- a/include/mmtf/binary_encoder.hpp
+++ b/include/mmtf/binary_encoder.hpp
@@ -98,21 +98,21 @@ inline std::vector<char> encodeInt8ToByte(std::vector<int8_t> vec_in);
  * @param[in] vec_in        Vector of ints to encode
  * @return Char vector of encoded bytes
  */
-inline std::vector<char> encodeFourByteInt(std::vector<int32_t> vec_in);
+inline std::vector<char> encodeFourByteInt(std::vector<int32_t> const & vec_in);
 
 /** Encode string vector encoding (type 5)
  * @param[in] in_sv         Vector of strings to encode
  * @param[in] CHAIN_LEN     Maximum length of string
  * @return Char vector of encoded bytes
  */
-inline std::vector<char> encodeStringVector(std::vector<std::string> in_sv, int32_t CHAIN_LEN);
+inline std::vector<char> encodeStringVector(std::vector<std::string> const & in_sv, int32_t const CHAIN_LEN);
 
 
 /** Encode Run Length Char encoding (type 6)
  * @param[in] in_cv         Vector of chars to encode
  * @return Char vector of encoded bytes
  */
-inline std::vector<char> encodeRunLengthChar(std::vector<char> in_cv);
+inline std::vector<char> encodeRunLengthChar(std::vector<char> const & in_cv);
 
 
 /** Encode Run Length Delta Int encoding (type 8)
@@ -126,20 +126,20 @@ inline std::vector<char> encodeRunLengthDeltaInt(std::vector<int32_t> int_vec);
  * @param[in] multiplier    Multiplier to convert float to int
  * @return Char vector of encoded bytes
  */
-inline std::vector<char> encodeRunLengthFloat(std::vector<float> floats_in, int32_t multiplier);
+inline std::vector<char> encodeRunLengthFloat(std::vector<float> const & floats_in, int32_t const multiplier);
 
 /** Encode Delta Recursive Float encoding (type 10)
  * @param[in] floats_in     Vector of floats to encode
  * @param[in] multiplier    Multiplier to convert float to int
  * @return Char vector of encoded bytes
  */
-inline std::vector<char> encodeDeltaRecursiveFloat(std::vector<float> floats_in, int32_t multiplier);
+inline std::vector<char> encodeDeltaRecursiveFloat(std::vector<float> const & floats_in, int32_t const multiplier);
 
 /** Encode Run-Length 8bit int encoding (type 16)
  * @param[in] int8_vec     Vector of ints to encode
  * @return Char vector of encoded bytes
  */
-inline std::vector<char> encodeRunLengthInt8(std::vector<int8_t> int8_vec);
+inline std::vector<char> encodeRunLengthInt8(std::vector<int8_t> const & int8_vec);
 
 // *************************************************************************
 // IMPLEMENTATION
@@ -148,7 +148,7 @@ inline std::vector<char> encodeRunLengthInt8(std::vector<int8_t> int8_vec);
 namespace { // private helpers
 
 inline std::vector<int32_t> convertFloatsToInts(std::vector<float> const & vec_in,
-                                            int multiplier) {
+                                            int const multiplier) {
   std::vector<int32_t> vec_out;
   for (size_t i=0; i<vec_in.size(); ++i) {
     vec_out.push_back(static_cast<int32_t>(round(vec_in[i]*multiplier)));
@@ -242,7 +242,7 @@ inline std::vector<char> encodeInt8ToByte(std::vector<int8_t> vec_in) {
 }
 
 
-inline std::vector<char> encodeFourByteInt(std::vector<int32_t> vec_in) {
+inline std::vector<char> encodeFourByteInt(std::vector<int32_t> const & vec_in) {
   std::stringstream ss;
   add_header(ss, vec_in.size(), 4, 0);
   for (size_t i=0; i<vec_in.size(); ++i) {
@@ -253,7 +253,7 @@ inline std::vector<char> encodeFourByteInt(std::vector<int32_t> vec_in) {
 }
 
 
-inline std::vector<char> encodeStringVector(std::vector<std::string> in_sv, int32_t CHAIN_LEN) {
+inline std::vector<char> encodeStringVector(std::vector<std::string> const & in_sv, int32_t const CHAIN_LEN) {
   char NULL_BYTE = 0x00;
   std::stringstream ss;
   add_header(ss, in_sv.size(), 5, CHAIN_LEN);
@@ -271,7 +271,7 @@ inline std::vector<char> encodeStringVector(std::vector<std::string> in_sv, int3
 }
 
 
-inline std::vector<char> encodeRunLengthChar(std::vector<char> in_cv) {
+inline std::vector<char> encodeRunLengthChar(std::vector<char> const & in_cv) {
   std::stringstream ss;
   add_header(ss, in_cv.size(), 6, 0);
   std::vector<int32_t> int_vec = runLengthEncode(in_cv);
@@ -295,7 +295,7 @@ inline std::vector<char> encodeRunLengthDeltaInt(std::vector<int32_t> int_vec) {
   return stringstreamToCharVector(ss);
 }
 
-inline std::vector<char> encodeRunLengthFloat(std::vector<float> floats_in, int32_t multiplier) {
+inline std::vector<char> encodeRunLengthFloat(std::vector<float> const & floats_in, int32_t const multiplier) {
   std::stringstream ss;
   add_header(ss, floats_in.size(), 9, multiplier);
   std::vector<int32_t> int_vec = convertFloatsToInts(floats_in, multiplier);
@@ -308,7 +308,7 @@ inline std::vector<char> encodeRunLengthFloat(std::vector<float> floats_in, int3
 }
 
 
-inline std::vector<char> encodeDeltaRecursiveFloat(std::vector<float> floats_in, int32_t multiplier) {
+inline std::vector<char> encodeDeltaRecursiveFloat(std::vector<float> const & floats_in, int32_t const multiplier) {
   std::stringstream ss;
   add_header(ss, floats_in.size(), 10, multiplier);
   std::vector<int32_t> int_vec = convertFloatsToInts(floats_in, multiplier);
@@ -322,10 +322,10 @@ inline std::vector<char> encodeDeltaRecursiveFloat(std::vector<float> floats_in,
 }
 
 
-inline std::vector<char> encodeRunLengthInt8(std::vector<int8_t> int8_vec) {
+inline std::vector<char> encodeRunLengthInt8(std::vector<int8_t> const & int8_vec) {
   std::stringstream ss;
   add_header(ss, int8_vec.size(), 16, 0);
-  std::vector<int32_t> int_vec = runLengthEncode(int8_vec);
+  std::vector<int32_t> const int_vec = runLengthEncode(int8_vec);
   for (size_t i=0; i<int_vec.size(); ++i) {
     int32_t temp = htonl(int_vec[i]);
     ss.write(reinterpret_cast< char * >(&temp), sizeof(temp));

--- a/include/mmtf/map_decoder.hpp
+++ b/include/mmtf/map_decoder.hpp
@@ -243,7 +243,7 @@ inline void MapDecoder::init_from_msgpack_obj(const msgpack::object& obj) {
 
 inline void MapDecoder::checkType_(const std::string& key,
                                    msgpack::type::object_type type,
-                                   const float& target) const {
+                                   const float&) const {
     if (type != msgpack::type::FLOAT32 && type != msgpack::type::FLOAT64) {
         std::cerr << "Warning: Non-float type " << type << " found for "
                      "entry " << key << std::endl;
@@ -251,7 +251,7 @@ inline void MapDecoder::checkType_(const std::string& key,
 }
 inline void MapDecoder::checkType_(const std::string& key,
                                    msgpack::type::object_type type,
-                                   const int32_t& target) const {
+                                   const int32_t&) const {
     if (   type != msgpack::type::POSITIVE_INTEGER
         && type != msgpack::type::NEGATIVE_INTEGER) {
         std::cerr << "Warning: Non-int type " << type << " found for "
@@ -260,7 +260,7 @@ inline void MapDecoder::checkType_(const std::string& key,
 }
 inline void MapDecoder::checkType_(const std::string& key,
                                    msgpack::type::object_type type,
-                                   const char& target) const {
+                                   const char&) const {
     if (type != msgpack::type::STR) {
         std::cerr << "Warning: Non-string type " << type << " found for "
                      "entry " << key << std::endl;
@@ -268,7 +268,7 @@ inline void MapDecoder::checkType_(const std::string& key,
 }
 inline void MapDecoder::checkType_(const std::string& key,
                                    msgpack::type::object_type type,
-                                   const std::string& target) const {
+                                   const std::string&) const {
     if (type != msgpack::type::STR) {
         std::cerr << "Warning: Non-string type " << type << " found for "
                      "entry " << key << std::endl;
@@ -278,7 +278,7 @@ inline void MapDecoder::checkType_(const std::string& key,
 template <typename T>
 void MapDecoder::checkType_(const std::string& key,
                             msgpack::type::object_type type,
-                            const std::vector<T>& target) const {
+                            const std::vector<T>&) const {
     if (type != msgpack::type::ARRAY && type != msgpack::type::BIN) {
         std::cerr << "Warning: Non-array type " << type << " found for "
                      "entry " << key << std::endl;
@@ -287,9 +287,9 @@ void MapDecoder::checkType_(const std::string& key,
 
 
 template <typename T>
-void MapDecoder::checkType_(const std::string& key,
-                            msgpack::type::object_type type,
-                            const T & target) const {
+void MapDecoder::checkType_(const std::string&,
+                            msgpack::type::object_type,
+                            const T &) const {
     // Do nothing -- allow all through
 }
 


### PR DESCRIPTION
This PR updates most of the BinaryDecoder methods to be const as they do not modify the internal class data.   It will make it more convenient and easier to use when passing BinaryDecoder instances through functions.