### PR TITLE
Fix segmentation fault with -march=native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,54 +4,65 @@ dist: trusty
 
 linux64_addons:
     addons: &linux64
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - g++-4.8
+        apt:
+            sources:
+                - ubuntu-toolchain-r-test
+            packages:
+                - g++-4.8
 
 linux32_addons:
     addons: &linux32
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - g++-4.8
-        - g++-4.8-multilib
-        - linux-libc-dev:i386
-        - libc6-dev-i386
+        apt:
+            sources:
+                - ubuntu-toolchain-r-test
+            packages:
+                - g++-4.8
+                - g++-4.8-multilib
+                - linux-libc-dev:i386
+                - libc6-dev-i386
+
+linux64_cpp17addons:
+    addons: &linux64cpp17
+        apt:
+            sources:
+                - ubuntu-toolchain-r-test
 
 # Set empty values for allow_failures to work
-env:
+env: TEST_COMMAND=$TRAVIS_BUILD_DIR/ci/build_and_run_tests.sh
 
 matrix:
-  fast_finish: true
-  include:
-    - os: linux
-      env: EMSCRIPTEN=ON
-      addons: *linux64
-    - os: linux
-      compiler: clang
-      addons: *linux64
-    - os: linux
-      compiler: gcc
-      env: ARCH=x86 CMAKE_EXTRA=-DHAVE_LIBM=/lib32/libm.so.6
-      addons: *linux32
-    - os: osx
-      compiler: clang
+    fast_finish: true
+    include:
+        - os: linux
+          env: EMSCRIPTEN=ON TEST_COMMAND=$TRAVIS_BUILD_DIR/ci/build_and_run_tests.sh
+          addons: *linux64
+        - os: linux
+          compiler: clang
+          addons: *linux64
+        - os: linux
+          compiler: gcc
+          env: ARCH=x86 CMAKE_EXTRA=-DHAVE_LIBM=/lib32/libm.so.6 TEST_COMMAND=$TRAVIS_BUILD_DIR/ci/build_and_run_tests.sh
+          addons: *linux32
+        - os: osx
+          compiler: clang
+        - os: linux
+          compiler: gcc
+          env: CMAKE_EXTRA="-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS='-march=native'" TEST_COMMAND=$TRAVIS_BUILD_DIR/ci/build_and_run_tests.sh
+          addons: *linux64cpp17
+          dist: bionic
+        - os: linux
+          compiler: gcc
+          addons: *linux64cpp17
+          dist: bionic
+
 
 before_install:
-  # Setting environement
-  - cd $TRAVIS_BUILD_DIR
-  - source ci/setup-travis.sh
-  - $CC --version
-  - $CXX --version
+    # Setting environement
+    - cd $TRAVIS_BUILD_DIR
+    - source ci/setup-travis.sh
+    - $CC --version
+    - $CXX --version
 
 script:
-  - cd $TRAVIS_BUILD_DIR
-  - mkdir build && cd build
-  - $CMAKE_CONFIGURE cmake $CMAKE_ARGS $CMAKE_EXTRA ..
-  - make -j2
-  - ctest -j2 --output-on-failure
-  - bash $TRAVIS_BUILD_DIR/ci/travis-test-example.sh
-  - cd $TRAVIS_BUILD_DIR
+    - echo $TEST_COMMAND
+    - (eval "$TEST_COMMAND")

--- a/ci/build_and_run_tests.sh
+++ b/ci/build_and_run_tests.sh
@@ -1,0 +1,7 @@
+cd $TRAVIS_BUILD_DIR
+mkdir build && cd build
+$CMAKE_CONFIGURE cmake $CMAKE_ARGS $CMAKE_EXTRA ..
+make -j2
+ctest -j2 --output-on-failure
+bash $TRAVIS_BUILD_DIR/ci/travis-test-example.sh
+cd $TRAVIS_BUILD_DIR

--- a/ci/build_and_run_tests.sh
+++ b/ci/build_and_run_tests.sh
@@ -1,3 +1,4 @@
+set -e
 cd $TRAVIS_BUILD_DIR
 mkdir build && cd build
 $CMAKE_CONFIGURE cmake $CMAKE_ARGS $CMAKE_EXTRA ..

--- a/ci/setup-travis.sh
+++ b/ci/setup-travis.sh
@@ -25,9 +25,17 @@ if [[ "$EMSCRIPTEN" == "ON" ]]; then
 fi
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    if [[ "$CC" == "gcc" ]]; then
-        export CC=gcc-4.8
-        export CXX=g++-4.8
+    if [[ "$TRAVIS_DIST" == "trusty" ]]; then
+        if [[ "$CC" == "gcc" ]]; then
+            export CC=gcc-4.8
+            export CXX=g++-4.8
+        fi
+    fi
+    if [[ "$TRAVIS_DIST" == "bionic" ]]; then
+        if [[ "$CC" == "gcc" ]]; then
+            export CC=gcc-7
+            export CXX=g++-7
+        fi
     fi
 fi
 

--- a/include/mmtf/binary_decoder.hpp
+++ b/include/mmtf/binary_decoder.hpp
@@ -140,11 +140,17 @@ namespace {
 
 #ifndef __EMSCRIPTEN__
 void assignBigendian4(void* dst, const char* src) {
-    *((uint32_t*)dst) = ntohl(*((uint32_t*)src));
+    uint32_t tmp;
+    std::memcpy(&tmp, src, sizeof(uint32_t));
+    tmp = ntohl(tmp);
+    std::memcpy(dst, &tmp, sizeof(uint32_t));
 }
 
 void assignBigendian2(void* dst, const char* src) {
-    *((uint16_t*)dst) = ntohs(*((uint16_t*)src));
+    uint16_t tmp;
+    std::memcpy(&tmp, src, sizeof(uint16_t));
+    tmp = ntohs(tmp);
+    std::memcpy(dst, &tmp, sizeof(uint16_t));
 }
 #else
 // Need to avoid how emscripten handles memory


### PR DESCRIPTION
Took over fix for #36 and modifications for Travis CI from #35 .

Important note: I had to add `set -e` to the bash script (`build_and_run_tests.sh`) which runs the test since otherwise a failing test wouldn't trigger a failure in CI.